### PR TITLE
Fix pie-chart not always being centered.

### DIFF
--- a/src/pie_chart.jsx
+++ b/src/pie_chart.jsx
@@ -37,8 +37,8 @@ const PieChart = React.createClass({
         return (
           <circle
             r={radius}
-            cx={radius}
-            cy={radius}
+            cx={center}
+            cy={center}
             fill={color}
             key={index}
           />


### PR DESCRIPTION
In the edge case when the pie chart contains one element, the rendered circle was centered _just_ a pixel off.