### PR TITLE
Remove className propType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master (unreleased)
 
+- Remove unused className propType
+
 ## 0.2.2
 
 - Fix centering when rendering as a circle

--- a/src/pie_chart.jsx
+++ b/src/pie_chart.jsx
@@ -9,7 +9,6 @@ const size = 100;
  */
 const PieChart = React.createClass({
   propTypes: {
-    className: PropTypes.string,
     slices: PropTypes.arrayOf(PropTypes.shape({
       color: PropTypes.string.isRequired, // hex color
       value: PropTypes.number.isRequired,


### PR DESCRIPTION
This was leftover from the original extraction of the component where we
were passing a className down to the rendered component. Since we don't
actually use this prop anywhere, I am removing this propType.