### PR TITLE
Change 0.3.2 -> 0.3.0 in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## master (unreleased)
 
-## 0.3.2
+## 0.3.0
 
 - Upgrade Babel from 5 to 6
 - Convert to ES2015 module


### PR DESCRIPTION
This was erroneously 0.3.2 instead of 0.3.0,
likely due to a copy/paste error.